### PR TITLE
Move cart to Firestore

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -30,12 +30,13 @@ exports.onCartItem = functions.firestore.document('/carts/{userId}/items/{itemId
 
   // Calculate the cart subtotal
   const subtotal = cartItems.reduce((acc, doc) => {
-    return acc + doc.price;
+    return acc + (doc.product.price * doc.quantity);
   }, 0);
 
   // Update the shipping/tax info in the cart
-  await cartRef.update({
+  await cartRef.set({
+    subtotal: subtotal,
     shipping: calculateShipping(subtotal, itemsCount),
     tax: calculateTax(subtotal)
-  });
+  }, { merge: true });
 });

--- a/lib/studies/shrine/app.dart
+++ b/lib/studies/shrine/app.dart
@@ -186,12 +186,6 @@ class _RestorableAppStateModel extends RestorableListenable<AppStateModel> {
     final categoryIndex = appData['category_index'] as int;
     appState.setCategory(categories[categoryIndex]);
 
-    // Reset cart items.
-    final cartItems = appData['cart_data'] as Map<dynamic, dynamic>;
-    cartItems.forEach((dynamic id, dynamic quantity) {
-      appState.addMultipleProductsToCart(id as int, quantity as int);
-    });
-
     return appState;
   }
 

--- a/lib/studies/shrine/expanding_bottom_sheet.dart
+++ b/lib/studies/shrine/expanding_bottom_sheet.dart
@@ -484,6 +484,7 @@ class _ExpandingBottomSheetState extends State<ExpandingBottomSheet> {
         ? _getDesktopGapAnimation(116)
         : const AlwaysStoppedAnimation(0);
 
+    // TODO: This should also come from Firestore!
     final Widget child = SizedBox(
       width: _widthAnimation.value,
       height: _heightAnimation.value,

--- a/lib/studies/shrine/model/product.dart
+++ b/lib/studies/shrine/model/product.dart
@@ -111,7 +111,7 @@ class Product {
 
   Map<String, dynamic> toMap(BuildContext context) {
     return <String, dynamic>{
-      'category': category.name(context).toString(),
+      'category': Category.toName(category),
       'id': id,
       'isFeatured': isFeatured,
       'name': name(context),

--- a/lib/studies/shrine/supplemental/product_card.dart
+++ b/lib/studies/shrine/supplemental/product_card.dart
@@ -89,7 +89,8 @@ Widget _buildProductCard({
             GalleryLocalizations.of(context).shrineScreenReaderProductAddToCart,
         child: GestureDetector(
           onTap: () {
-            model.addProductToCart(product.id);
+            final productData = product.toMap(context);
+            model.addProductToCart(product.id, productData);
           },
           child: child,
         ),


### PR DESCRIPTION
Changes:

- Adding/removing goes through Firestore
- Cart subtotal/tax/shipping comes from Firestore (via functions)
- Change cart items to be `{ quantity: <int>, product: <object> }`

TODO:

- [ ] The bottom thumbnail row is still based on local state